### PR TITLE
[gomod] Use a temporary working copy of the input repository

### DIFF
--- a/cachi2/core/package_managers/gomod.py
+++ b/cachi2/core/package_managers/gomod.py
@@ -899,7 +899,6 @@ def _resolve_gomod(
         modules_in_go_sum = _parse_go_sum(app_dir.join_within_root("go.sum"))
 
     # Vendor dependencies if the gomod-vendor flag is set
-    flags = request.flags
     if should_vendor:
         if go_work_path and go_work_path.join_within_root("vendor").path.is_dir():
             # NOTE: the same error will be reported even for 1.21 which doesn't support workspace
@@ -914,9 +913,6 @@ def _resolve_gomod(
             ParsedModule.model_validate(obj)
             for obj in load_json_stream(go(["mod", "download", "-json"], run_params, retry=True))
         )
-
-    if "force-gomod-tidy" in flags:
-        go(["mod", "tidy"], run_params)
 
     go_list = ["list", "-e"]
     if not should_vendor:

--- a/cachi2/core/resolver.py
+++ b/cachi2/core/resolver.py
@@ -39,7 +39,7 @@ def resolve_packages(request: Request) -> RequestOutput:
     This function performs the operations in a working copy of the source directory in case
     a package manager that can make unwanted modifications will be used.
     """
-    if request.yarn_packages or request.yarn_classic_packages:
+    if request.yarn_packages or request.yarn_classic_packages or request.gomod_packages:
         original_source_dir = request.source_dir
 
         with TemporaryDirectory(".cachi2-source-copy", dir=".") as temp_dir:

--- a/cachi2/interface/cli.py
+++ b/cachi2/interface/cli.py
@@ -160,7 +160,10 @@ def fetch_deps(
     force_gomod_tidy: bool = typer.Option(
         False,
         "--force-gomod-tidy",
-        help="Run 'go mod tidy' after downloading go dependencies.",
+        help=(
+            "DEPRECATED (no longer has any effect when set). "
+            "Run 'go mod tidy' after downloading go dependencies."
+        ),
     ),
     gomod_vendor: bool = typer.Option(
         False,

--- a/docs/gomod.md
+++ b/docs/gomod.md
@@ -90,12 +90,12 @@ by Cachi2 anyway.
 The `cachi2 fetch-deps` command accepts the following gomod-related flags:
 
 * [--cgo-disable](#--cgo-disable)
-* [--force-gomod-tidy](#--force-gomod-tidy)
 
 ### Deprecated flags
 
 * `--gomod-vendor` (deprecated in _v0.11.0_)
 * `--gomod-vendor-check` (deprecated in _v0.11.0_)
+* `--force-gomod-tidy` (deprecated in _v0.13.0_)
 
 All of them are deprecated and will have no effect when set. They are only kept for backwards
 compatibility reasons and will be removed in future releases.
@@ -108,12 +108,6 @@ disable cgo in your build (nor should you disable it yourself if you rely on C).
 
 Disabling cgo should not prevent Cachi2 from fetching your Go dependencies as usual. Note that Cachi2 will not make any
 attempts to fetch missing C libraries. If required, you would need to get them through other means.
-
-### --force-gomod-tidy
-
-Makes Cachi2 run `go mod tidy` after downloading dependencies.
-
-⚠ This flag is questionable and may be removed in the future.
 
 ## Vendoring
 

--- a/docs/gomod.md
+++ b/docs/gomod.md
@@ -94,10 +94,11 @@ The `cachi2 fetch-deps` command accepts the following gomod-related flags:
 
 ### Deprecated flags
 
-* `--gomod-vendor`
-* `--gomod-vendor-check`
+* `--gomod-vendor` (deprecated in _v0.11.0_)
+* `--gomod-vendor-check` (deprecated in _v0.11.0_)
 
-Both are deprecated and will have no effect when set. They are only kept for backwards compatibility reasons.
+All of them are deprecated and will have no effect when set. They are only kept for backwards
+compatibility reasons and will be removed in future releases.
 
 ### --cgo-disable
 

--- a/docs/gomod.md
+++ b/docs/gomod.md
@@ -91,8 +91,6 @@ The `cachi2 fetch-deps` command accepts the following gomod-related flags:
 
 * [--cgo-disable](#--cgo-disable)
 * [--force-gomod-tidy](#--force-gomod-tidy)
-* --gomod-vendor - see [vendoring](#vendoring)
-* --gomod-vendor-check - see [vendoring](#vendoring)
 
 ### --cgo-disable
 

--- a/docs/gomod.md
+++ b/docs/gomod.md
@@ -92,6 +92,13 @@ The `cachi2 fetch-deps` command accepts the following gomod-related flags:
 * [--cgo-disable](#--cgo-disable)
 * [--force-gomod-tidy](#--force-gomod-tidy)
 
+### Deprecated flags
+
+* `--gomod-vendor`
+* `--gomod-vendor-check`
+
+Both are deprecated and will have no effect when set. They are only kept for backwards compatibility reasons.
+
 ### --cgo-disable
 
 Makes Cachi2 internally disable [cgo](https://pkg.go.dev/cmd/cgo) while processing your Go modules. Typically, you would
@@ -116,15 +123,6 @@ directory alongside your module. Before go 1.17, `go mod vendor` used to downloa
 We generally discourage vendoring, but Cachi2 does support processing repositories that contain vendored content. In
 this case, instead of a regular prefetching of dependencies, Cachi2 will only validate if the contents of the vendor
 directory are consistent with what `go mod vendor` would produce.
-
-### Deprecated flags
-
-Cachi2's behavior towards vendoring used to be governed by two flags:
-
-* `--gomod-vendor`
-* `--gomod-vendor-check`
-
-Both are deprecated and will have no effect when set. They are only kept for backwards compatibility reasons.
 
 ## Understanding reported dependencies
 


### PR DESCRIPTION
Depends on: #714 
Relates to: https://github.com/containerbuildsystem/cachi2/issues/707

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
