### PR TITLE
[reorg] Replace mentions of the old containerbuildsystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,8 +259,8 @@ See [docs/yarn.md](docs/yarn.md) for more details.
 
 Cachi2 was derived (but is not a direct fork) from [Cachito](https://github.com/containerbuildsystem/cachito).
 
-[cachi2-coverage-badge]: https://codecov.io/github/containerbuildsystem/cachi2/graph/badge.svg?token=VJKRTZQBMY
-[cachi2-coverage-status]: https://codecov.io/github/containerbuildsystem/cachi2
+[cachi2-coverage-badge]: https://codecov.io/github/hermetoproject/cachi2/graph/badge.svg?token=VJKRTZQBMY
+[cachi2-coverage-status]: https://codecov.io/github/hermetoproject/cachi2
 
 [cachi2-container-badge]: https://img.shields.io/badge/container-latest-blue
 [cachi2-container-status]: https://quay.io/repository/konflux-ci/cachi2/tag/latest

--- a/cachi2/core/package_managers/bundler/main.py
+++ b/cachi2/core/package_managers/bundler/main.py
@@ -142,7 +142,7 @@ def _get_name_and_version_from_lockfile(dependencies: ParseResult) -> Optional[t
     version, and other metadata even if the package is not a gem. So we respect this edge case.
 
     See design doc for more details:
-    https://github.com/containerbuildsystem/cachi2/blob/main/docs/design/bundler.md
+    https://github.com/hermetoproject/cachi2/blob/main/docs/design/bundler.md
     """
     for dep in dependencies:
         if isinstance(dep, PathDependency) and dep.subpath == ".":

--- a/cachi2/core/package_managers/gomod.py
+++ b/cachi2/core/package_managers/gomod.py
@@ -48,7 +48,7 @@ from cachi2.core.utils import get_cache_dir, load_json_stream, run_cmd
 log = logging.getLogger(__name__)
 
 
-GOMOD_DOC = "https://github.com/containerbuildsystem/cachi2/blob/main/docs/gomod.md"
+GOMOD_DOC = "https://github.com/hermetoproject/cachi2/blob/main/docs/gomod.md"
 GOMOD_INPUT_DOC = f"{GOMOD_DOC}#specifying-modules-to-process"
 VENDORING_DOC = f"{GOMOD_DOC}#vendoring"
 

--- a/cachi2/core/package_managers/pip.py
+++ b/cachi2/core/package_managers/pip.py
@@ -70,16 +70,14 @@ SDIST_EXT_PATTERN = r"|".join(map(re.escape, SDIST_FILE_EXTENSIONS))
 
 PYPI_URL = "https://pypi.org"
 
-PIP_METADATA_DOC = (
-    "https://github.com/containerbuildsystem/cachi2/blob/main/docs/pip.md#project-metadata"
-)
+PIP_METADATA_DOC = "https://github.com/hermetoproject/cachi2/blob/main/docs/pip.md#project-metadata"
 PIP_REQUIREMENTS_TXT_DOC = (
-    "https://github.com/containerbuildsystem/cachi2/blob/main/docs/pip.md#requirementstxt"
+    "https://github.com/hermetoproject/cachi2/blob/main/docs/pip.md#requirementstxt"
 )
 PIP_EXTERNAL_DEPS_DOC = (
-    "https://github.com/containerbuildsystem/cachi2/blob/main/docs/pip.md#external-dependencies"
+    "https://github.com/hermetoproject/cachi2/blob/main/docs/pip.md#external-dependencies"
 )
-PIP_NO_SDIST_DOC = "https://github.com/containerbuildsystem/cachi2/blob/main/docs/pip.md#dependency-does-not-distribute-sources"
+PIP_NO_SDIST_DOC = "https://github.com/hermetoproject/cachi2/blob/main/docs/pip.md#dependency-does-not-distribute-sources"
 
 
 @dataclass

--- a/cachi2/core/resolver.py
+++ b/cachi2/core/resolver.py
@@ -51,7 +51,7 @@ def resolve_packages(request: Request) -> RequestOutput:
 
             # Temporary solution to project files paths that are pointing to the work copy.
             # Should be replaced once we extend the work copy solution to other package managers.
-            # https://github.com/containerbuildsystem/cachi2/issues/712
+            # https://github.com/hermetoproject/cachi2/issues/712
             for project_file in output.build_config.project_files:
                 subpath = project_file.abspath.relative_to(source_backup)
                 project_file.abspath = original_source_dir / subpath

--- a/docs/adr/0002-yarn-v4.md
+++ b/docs/adr/0002-yarn-v4.md
@@ -106,7 +106,7 @@ $ cat package.json
 
 This used to be a configurable key in the `.yarnrc.yml` file. The previous default path, `./.pnp.data.json`, is now hard-coded and can't be changed.
 
-The only mention to `pnpDataPath` in Cachi2 is the [check](https://github.com/containerbuildsystem/cachi2/blob/a5f19c6f9be90be4289beee35ecccd2827bbb328/cachi2/core/package_managers/yarn/main.py#L43) for paths pointing outside of the repo. The check can be kept the same way so Yarn v3 can still be covered, and it will simply be skipped in v4.
+The only mention to `pnpDataPath` in Cachi2 is the [check](https://github.com/hermetoproject/cachi2/blob/a5f19c6f9be90be4289beee35ecccd2827bbb328/cachi2/core/package_managers/yarn/main.py#L43) for paths pointing outside of the repo. The check can be kept the same way so Yarn v3 can still be covered, and it will simply be skipped in v4.
 
 #### Yarn now caches npm version metadata
 
@@ -128,7 +128,7 @@ The metadata, in itself, is a collection of json files with a few kilobytes each
 
 #### Changes to yarn.lock
 
-When updating v3 projects to v4, some differences in the lockfile appear. These are some picks from updating the [disallowed-protocols](https://github.com/cachito-testing/cachi2-yarn-berry/tree/disallowed-protocols) branch on the cachi2-yarn-berry test project:
+When updating v3 projects to v4, some differences in the lockfile appear. These are some picks from updating the [disallowed-protocols](https://github.com/hermetoproject/integration-tests/tree/yarn/disallowed-protocols) branch on the in our integration test suite:
 
 **`npm:` locator added to npm dependencies:**
 ```
@@ -155,7 +155,7 @@ When updating v3 projects to v4, some differences in the lockfile appear. These 
 +  resolution: "strip-ansi-tarball@file:external-packages/strip-ansi-4.0.0.tgz#external-packages/strip-ansi-4.0.0.tgz::hash=e17689&locator=berryscary%40workspace%3A."
 ```
 
-Yarn v4 introduced the subdirectory (`#external-packages/strip-ansi-4.0.0.tgz`) and the hash (`::hash=e17689`) to the previously existing locator. These parts are already [handled](https://github.com/containerbuildsystem/cachi2/blob/a5f19c6f9be90be4289beee35ecccd2827bbb328/cachi2/core/package_managers/yarn/locators.py#L77-L79) by the v3 implementation in Cachi2, though.
+Yarn v4 introduced the subdirectory (`#external-packages/strip-ansi-4.0.0.tgz`) and the hash (`::hash=e17689`) to the previously existing locator. These parts are already [handled](https://github.com/hermetoproject/cachi2/blob/a5f19c6f9be90be4289beee35ecccd2827bbb328/cachi2/core/package_managers/yarn/locators.py#L77-L79) by the v3 implementation in Cachi2, though.
 
 **Changes to some instances of the patch locator:**
 ```
@@ -163,7 +163,7 @@ Yarn v4 introduced the subdirectory (`#external-packages/strip-ansi-4.0.0.tgz`) 
 +  resolution: "typescript@patch:typescript@npm%3A5.1.6#optional!builtin<compat/typescript>::version=5.1.6&hash=5da071"
 ```
 
-Instances of the patch locator are currently [being ignored](https://github.com/containerbuildsystem/cachi2/blob/a5f19c6f9be90be4289beee35ecccd2827bbb328/cachi2/core/package_managers/yarn/resolver.py#L264-L268) in the v3 implementation in Cachi2.
+Instances of the patch locator are currently [being ignored](https://github.com/hermetoproject/cachi2/blob/a5f19c6f9be90be4289beee35ecccd2827bbb328/cachi2/core/package_managers/yarn/resolver.py#L264-L268) in the v3 implementation in Cachi2.
 
 #### Hardened mode
 

--- a/docs/dependency_confusion.md
+++ b/docs/dependency_confusion.md
@@ -63,19 +63,19 @@ dependency attacks.
 
 ## pip
 
-*TL;DR: if your package is Cachito compliant, it is most likely safe. If you want to be sure, verify
+*TL;DR: if your package is Cachi2 compliant, it is most likely safe. If you want to be sure, verify
 checksums.*
 
 Python packages can have various formats, which are specified across multiple PEPs. Pip supports
-most of them. Cachito support for pip, on the other hand, is quite simple. You must define all the
+most of them. Cachi2 support for pip, on the other hand, is quite simple. You must define all the
 direct and indirect dependencies of your package in
 [requirements.txt](https://pip.pypa.io/en/stable/user_guide/#requirements-files) style files and
-tell Cachito to process them.
+tell Cachi2 to process them.
 
-Cachito further restricts what you can put in your requirements.txt files. All of the dependencies
+Cachi2 further restricts what you can put in your requirements.txt files. All of the dependencies
 must be
 [pinned](https://github.com/release-engineering/cachito/blob/master/docs/pip.md#pinning-versions)
-to an exact version. Cachito will refuse to process requirements files that use the --index-url or
+to an exact version. Cachi2 will refuse to process requirements files that use the --index-url or
 --extra-index-url options, which means private registries are out of the question. These two
 restrictions should eliminate most attack vectors.
 
@@ -88,22 +88,22 @@ specific commit.
 
 ## npm
 
-*TL;DR: do not use unofficial registries. Even if you try to do so via .npmrc, Cachito will ignore
+*TL;DR: do not use unofficial registries. Even if you try to do so via .npmrc, Cachi2 will ignore
 it.*
 
 Npm packages follow the typical package file + lock file approach. The package file is
 [package.json](https://docs.npmjs.com/cli/v6/configuring-npm/package-json), the lock file is
 [package-lock.json](https://docs.npmjs.com/cli/v6/configuring-npm/package-lock-json) or
-[npm-shrinkwrap.json](https://docs.npmjs.com/cli/v6/configuring-npm/shrinkwrap-json). Cachito
+[npm-shrinkwrap.json](https://docs.npmjs.com/cli/v6/configuring-npm/shrinkwrap-json). Cachi2
 requires the lock file.
 
 The lock file pins all dependencies to exact versions. For https dependencies, which are impossible
-to pin, Cachito requires the integrity value (a checksum). For dependencies from the npm registry,
-Cachito does not require integrity values, but newer versions of npm will always include them. Check
+to pin, Cachi2 requires the integrity value (a checksum). For dependencies from the npm registry,
+Cachi2 does not require integrity values, but newer versions of npm will always include them. Check
 if all your dependencies have an integrity value, update your lock file if not.
 
 Do not try to use private registries. If you point npm to a private registry (or any registry other
-than the official one) via [.npmrc](https://docs.npmjs.com/cli/v6/configuring-npm/npmrc), Cachito
+than the official one) via [.npmrc](https://docs.npmjs.com/cli/v6/configuring-npm/npmrc), Cachi2
 will ignore it and look in the official registry anyway.
 
 ## yarn
@@ -117,9 +117,9 @@ applies to npm applies to yarn.
 
 The one difference is the handling of unofficial registries. If you point yarn to an unofficial
 registry via .npmrc or [.yarnrc](https://classic.yarnpkg.com/en/docs/yarnrc), this will be reflected
-in the resolved url in the lock file. Cachito will see that the url does not point to the official
+in the resolved url in the lock file. Cachi2 will see that the url does not point to the official
 registry and will treat the dependency as a plain https dependency. If the url is accessible to
-Cachito, it will download the dependency directly without relying on npm/yarn dependency resolution.
+Cachi2, it will download the dependency directly without relying on npm/yarn dependency resolution.
 That does not necessarily make using unofficial registries a good idea. If the registry is private,
 your build will either fail or leak internal package names.
 
@@ -127,7 +127,7 @@ your build will either fail or leak internal package names.
 
 *TL;DR: allowing `https://rubygems.org` as the only source should mitigate the issue for GEM dependencies*
 
-Cachito parses `Gemfile.lock` which pins all dependencies to exact versions. Cachito allows GEM dependencies
+Cachi2 parses `Gemfile.lock` which pins all dependencies to exact versions. Cachi2 allows GEM dependencies
 to be fetched only from `https://rubygems.org`, otherwise raises an error. GIT dependencies are specified using
 a repo URL and pinned to a commit hash.
 

--- a/docs/dependency_confusion.md
+++ b/docs/dependency_confusion.md
@@ -75,9 +75,9 @@ tell Cachi2 to process them.
 Cachi2 further restricts what you can put in your requirements.txt files. All of the dependencies
 must be
 [pinned](https://github.com/release-engineering/cachito/blob/master/docs/pip.md#pinning-versions)
-to an exact version. Cachi2 will refuse to process requirements files that use the --index-url or
---extra-index-url options, which means private registries are out of the question. These two
-restrictions should eliminate most attack vectors.
+to an exact version. Cachi2 will refuse to process requirements files that use the
+--extra-index-url option, which means that if a private registry is to be specified, only a single
+one supported and the `--index-url` option should be used.
 
 To protect yourself even further, use pip’s
 [hash-checking mode](https://pip.pypa.io/en/stable/reference/pip_install/#hash-checking-mode). Note

--- a/docs/dependency_confusion.md
+++ b/docs/dependency_confusion.md
@@ -61,80 +61,76 @@ to verify that the content of all direct and indirect dependencies is what you e
 As long as you make sure to always commit your go.sum file, your Golang module should be safe from
 dependency attacks.
 
-## *[Cachito][cachito-1] also supports the following package managers, but Cachi2 does not (yet).*
+## pip
 
-> ## pip
->
-> *TL;DR: if your package is Cachito compliant, it is most likely safe. If you want to be sure, verify
-> checksums.*
->
-> Python packages can have various formats, which are specified across multiple PEPs. Pip supports
-> most of them. Cachito support for pip, on the other hand, is quite simple. You must define all the
-> direct and indirect dependencies of your package in
-> [requirements.txt](https://pip.pypa.io/en/stable/user_guide/#requirements-files) style files and
-> tell Cachito to process them.
->
-> Cachito further restricts what you can put in your requirements.txt files. All of the dependencies
-> must be
-> [pinned](https://github.com/release-engineering/cachito/blob/master/docs/pip.md#pinning-versions)
-> to an exact version. Cachito will refuse to process requirements files that use the --index-url or
-> --extra-index-url options, which means private registries are out of the question. These two
-> restrictions should eliminate most attack vectors.
->
-> To protect yourself even further, use pip’s
-> [hash-checking mode](https://pip.pypa.io/en/stable/reference/pip_install/#hash-checking-mode). Note
-> that pip does not support hash checking for VCS dependencies, e.g. git. Consider transforming your
-> git dependencies to plain https dependencies. For example, if the repository is hosted on github,
-> you can use https://github.com/{org_name}/{repo_name}/{commit_id}.tar.gz to get the tarball for a
-> specific commit.
->
-> ## npm
->
-> *TL;DR: do not use unofficial registries. Even if you try to do so via .npmrc, Cachito will ignore
-> it.*
->
-> Npm packages follow the typical package file + lock file approach. The package file is
-> [package.json](https://docs.npmjs.com/cli/v6/configuring-npm/package-json), the lock file is
-> [package-lock.json](https://docs.npmjs.com/cli/v6/configuring-npm/package-lock-json) or
-> [npm-shrinkwrap.json](https://docs.npmjs.com/cli/v6/configuring-npm/shrinkwrap-json). Cachito
-> requires the lock file.
->
-> The lock file pins all dependencies to exact versions. For https dependencies, which are impossible
-> to pin, Cachito requires the integrity value (a checksum). For dependencies from the npm registry,
-> Cachito does not require integrity values, but newer versions of npm will always include them. Check
-> if all your dependencies have an integrity value, update your lock file if not.
->
-> Do not try to use private registries. If you point npm to a private registry (or any registry other
-> than the official one) via [.npmrc](https://docs.npmjs.com/cli/v6/configuring-npm/npmrc), Cachito
-> will ignore it and look in the official registry anyway.
->
-> ## yarn
->
-> *TL;DR: same as npm, but the handling of unofficial registries is slightly less surprising. Still,
-> you probably should not use them.*
->
-> Yarn packages are identical to npm packages except that they use
-> [yarn.lock](https://classic.yarnpkg.com/en/docs/yarn-lock/) as the lock file. Everything that
-> applies to npm applies to yarn.
->
-> The one difference is the handling of unofficial registries. If you point yarn to an unofficial
-> registry via .npmrc or [.yarnrc](https://classic.yarnpkg.com/en/docs/yarnrc), this will be reflected
-> in the resolved url in the lock file. Cachito will see that the url does not point to the official
-> registry and will treat the dependency as a plain https dependency. If the url is accessible to
-> Cachito, it will download the dependency directly without relying on npm/yarn dependency resolution.
-> That does not necessarily make using unofficial registries a good idea. If the registry is private,
-> your build will either fail or leak internal package names.
->
-> ## RubyGems (Bundler)
->
-> *TL;DR: allowing `https://rubygems.org` as the only source should mitigate the issue for GEM dependencies*
->
-> Cachito parses `Gemfile.lock` which pins all dependencies to exact versions. Cachito allows GEM dependencies
-> to be fetched only from `https://rubygems.org`, otherwise raises an error. GIT dependencies are specified using
-> a repo URL and pinned to a commit hash.
->
-> Bundler doesn't verify checksums of dependencies yet, however, there's an effort to bring
-> [internal GitLab implementation](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/92633)
-> to [the upstream](https://github.com/rubygems/rubygems/pull/5808).
+*TL;DR: if your package is Cachito compliant, it is most likely safe. If you want to be sure, verify
+checksums.*
 
-[cachito-1]: https://github.com/containerbuildsystem/cachito
+Python packages can have various formats, which are specified across multiple PEPs. Pip supports
+most of them. Cachito support for pip, on the other hand, is quite simple. You must define all the
+direct and indirect dependencies of your package in
+[requirements.txt](https://pip.pypa.io/en/stable/user_guide/#requirements-files) style files and
+tell Cachito to process them.
+
+Cachito further restricts what you can put in your requirements.txt files. All of the dependencies
+must be
+[pinned](https://github.com/release-engineering/cachito/blob/master/docs/pip.md#pinning-versions)
+to an exact version. Cachito will refuse to process requirements files that use the --index-url or
+--extra-index-url options, which means private registries are out of the question. These two
+restrictions should eliminate most attack vectors.
+
+To protect yourself even further, use pip’s
+[hash-checking mode](https://pip.pypa.io/en/stable/reference/pip_install/#hash-checking-mode). Note
+that pip does not support hash checking for VCS dependencies, e.g. git. Consider transforming your
+git dependencies to plain https dependencies. For example, if the repository is hosted on github,
+you can use https://github.com/{org_name}/{repo_name}/{commit_id}.tar.gz to get the tarball for a
+specific commit.
+
+## npm
+
+*TL;DR: do not use unofficial registries. Even if you try to do so via .npmrc, Cachito will ignore
+it.*
+
+Npm packages follow the typical package file + lock file approach. The package file is
+[package.json](https://docs.npmjs.com/cli/v6/configuring-npm/package-json), the lock file is
+[package-lock.json](https://docs.npmjs.com/cli/v6/configuring-npm/package-lock-json) or
+[npm-shrinkwrap.json](https://docs.npmjs.com/cli/v6/configuring-npm/shrinkwrap-json). Cachito
+requires the lock file.
+
+The lock file pins all dependencies to exact versions. For https dependencies, which are impossible
+to pin, Cachito requires the integrity value (a checksum). For dependencies from the npm registry,
+Cachito does not require integrity values, but newer versions of npm will always include them. Check
+if all your dependencies have an integrity value, update your lock file if not.
+
+Do not try to use private registries. If you point npm to a private registry (or any registry other
+than the official one) via [.npmrc](https://docs.npmjs.com/cli/v6/configuring-npm/npmrc), Cachito
+will ignore it and look in the official registry anyway.
+
+## yarn
+
+*TL;DR: same as npm, but the handling of unofficial registries is slightly less surprising. Still,
+you probably should not use them.*
+
+Yarn packages are identical to npm packages except that they use
+[yarn.lock](https://classic.yarnpkg.com/en/docs/yarn-lock/) as the lock file. Everything that
+applies to npm applies to yarn.
+
+The one difference is the handling of unofficial registries. If you point yarn to an unofficial
+registry via .npmrc or [.yarnrc](https://classic.yarnpkg.com/en/docs/yarnrc), this will be reflected
+in the resolved url in the lock file. Cachito will see that the url does not point to the official
+registry and will treat the dependency as a plain https dependency. If the url is accessible to
+Cachito, it will download the dependency directly without relying on npm/yarn dependency resolution.
+That does not necessarily make using unofficial registries a good idea. If the registry is private,
+your build will either fail or leak internal package names.
+
+## RubyGems (Bundler)
+
+*TL;DR: allowing `https://rubygems.org` as the only source should mitigate the issue for GEM dependencies*
+
+Cachito parses `Gemfile.lock` which pins all dependencies to exact versions. Cachito allows GEM dependencies
+to be fetched only from `https://rubygems.org`, otherwise raises an error. GIT dependencies are specified using
+a repo URL and pinned to a commit hash.
+
+Bundler doesn't verify checksums of dependencies yet, however, there's an effort to bring
+[internal GitLab implementation](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/92633)
+to [the upstream](https://github.com/rubygems/rubygems/pull/5808).

--- a/docs/design/bundler.md
+++ b/docs/design/bundler.md
@@ -612,7 +612,3 @@ PATH
 
 ### References
 This design doc was partially based on the original implementation done in [Cachito](https://github.com/containerbuildsystem/cachito/blob/master/cachito/workers/pkg_managers/rubygems.py). Since Cachi2 has different design goals from Cachito, the implementation here will deviate from the original one, with a key difference being that Cachi2 needs to provide a way to perform an [offline install](#providing-the-content-for-the-hermetic-build) from the local prefetched content.
-
-Cachito parses the `Gemfile.lock` via [gemlock-parser](https://github.com/containerbuildsystem/gemlock-parser),
-which is vendored from
-[scancode-toolkit](https://github.com/nexB/scancode-toolkit/blob/develop/src/packagedcode/gemfile_lock.py), which can also be leveraged by Cachi2.

--- a/docs/design/bundler.md
+++ b/docs/design/bundler.md
@@ -308,7 +308,7 @@ GIT
 
 #### Platform (i.e. pre-compiled) gems
 By default, binary gems are ignored for similar reasons as with [pip
-wheels](https://github.com/containerbuildsystem/cachi2/blob/main/docs/pip.md#distribution-formats),
+wheels](https://github.com/hermetoproject/cachi2/blob/main/docs/pip.md#distribution-formats),
 i.e. lacking sources which report in the SBOM.
 Platforms that relate to specific architectures will contain
 binaries that were pre-compiled for that architecture (see [Platforms](#platforms)).

--- a/docs/design/yarn-v1.md
+++ b/docs/design/yarn-v1.md
@@ -143,7 +143,7 @@ The user build can be configured to use the offline mirror by configuring the fo
     YARN_YARN_OFFLINE_MIRROR_PRUNING=false
 
 ## Implementation Scoping
- - Since we're executing Yarn commands directly, process the request in an [isolated temporary directory](https://github.com/containerbuildsystem/cachi2/blob/6953607b6ef52fd3f0bef7059d2c926767b1022b/cachi2/core/resolver.py#L41) to avoid any potential changes to the repository
+ - Since we're executing Yarn commands directly, process the request in an [isolated temporary directory](https://github.com/hermetoproject/cachi2/blob/6953607b6ef52fd3f0bef7059d2c926767b1022b/cachi2/core/resolver.py#L41) to avoid any potential changes to the repository
  - Determine whether to process the request with yarn v1 or yarn v2+
  - Read the project files
    - Read/Require package.json

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -118,7 +118,7 @@ cachi2 merge-sboms <cachi2_sbom_1.json> ... <cachi2_sbom_n.json>
 
 The subcommand expects at least two SBOMs, all produced by Cachi2, and will exit with error
 otherwise. The reason for this is that Cachi2 supports a
-[limited set](https://github.com/containerbuildsystem/cachi2/blob/main/cachi2/core/models/sbom.py#L7-L13)
+[limited set](https://github.com/hermetoproject/cachi2/blob/main/cachi2/core/models/sbom.py#L7-L13)
 of component [properties](https://cyclonedx.org/docs/1.4/json/#components_items_properties),
 and it validates that no other properties exist in the SBOM. By default the result of a merge
 will be printed to stdout. To save it to a file use `-o` option:

--- a/tests/unit/data/sboms/cachi2.bom.json
+++ b/tests/unit/data/sboms/cachi2.bom.json
@@ -44,7 +44,7 @@
                 }
             ],
             "version": "0.0.1",
-            "purl": "pkg:pypi/cachi2@0.0.1?vcs_url=git%2Bssh://git%40github.com/containerbuildsystem/cachi2%40fc0d6079c2dc9b2a491c0848e550ad3509986110",
+            "purl": "pkg:pypi/cachi2@0.0.1?vcs_url=git%2Bssh://git%40github.com/hermetoproject/cachi2%40fc0d6079c2dc9b2a491c0848e550ad3509986110",
             "type": "library"
         },
         {

--- a/tests/unit/data/sboms/cachi2.bom.spdx.json
+++ b/tests/unit/data/sboms/cachi2.bom.spdx.json
@@ -67,7 +67,7 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:pypi/cachi2@0.0.1?vcs_url=git%2Bssh://git%40github.com/containerbuildsystem/cachi2%40fc0d6079c2dc9b2a491c0848e550ad3509986110"
+          "referenceLocator": "pkg:pypi/cachi2@0.0.1?vcs_url=git%2Bssh://git%40github.com/hermetoproject/cachi2%40fc0d6079c2dc9b2a491c0848e550ad3509986110"
         }
       ]
     },

--- a/tests/unit/data/sboms/merged.bom.spdx.json
+++ b/tests/unit/data/sboms/merged.bom.spdx.json
@@ -220,7 +220,7 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:pypi/cachi2@0.0.1?vcs_url=git%2Bssh://git%40github.com/containerbuildsystem/cachi2%40fc0d6079c2dc9b2a491c0848e550ad3509986110"
+          "referenceLocator": "pkg:pypi/cachi2@0.0.1?vcs_url=git%2Bssh://git%40github.com/hermetoproject/cachi2%40fc0d6079c2dc9b2a491c0848e550ad3509986110"
         }
       ]
     },


### PR DESCRIPTION
The project moved to a new GitHub organization "hermetoproject". Change the references accordingly.
# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
