### PR TITLE
[tests] Integration test fixes

### DIFF
--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -478,19 +478,19 @@ def build_image_and_check_cmd(
     log.info("Build container image with all prerequisites retrieved in previous steps")
     container_folder = test_data_dir.joinpath(test_case, "container")
 
-    test_image = build_image_for_test_case(
+    with build_image_for_test_case(
         source_dir=test_repo_dir,
         output_dir=tmp_path,
         containerfile_path=container_folder.joinpath("Containerfile"),
         test_case=test_case,
-    )
+    ) as test_image:
 
-    log.info(f"Run command {check_cmd} on built image {test_image.repository}")
-    (output, exit_code) = test_image.run_cmd_on_image(check_cmd, tmp_path)
+        log.info(f"Run command {check_cmd} on built image {test_image.repository}")
+        (output, exit_code) = test_image.run_cmd_on_image(check_cmd, tmp_path)
 
-    assert exit_code == 0, f"{check_cmd} command failed, Output: {output}"
-    for expected_output in expected_cmd_output:
-        assert expected_output in output, f"{expected_output} is missing in {output}"
+        assert exit_code == 0, f"{check_cmd} command failed, Output: {output}"
+        for expected_output in expected_cmd_output:
+            assert expected_output in output, f"{expected_output} is missing in {output}"
 
 
 def _replace_tmp_path_with_placeholder(


### PR DESCRIPTION
A couple of small fixes that either fix a regression after the IT test suite repo consolidation or that have bothered me for a while.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
