### PR TITLE
[gomod] Bump the max supported version to 1.24

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Planned:
 
 <https://go.dev/ref/mod>
 
-Current version: 1.23 [^go-version] [^go-compat]
+Current version: 1.24 [^go-version] [^go-compat]
 
 The gomod package manager works by parsing the [go.mod](https://go.dev/ref/mod#go-mod-file) file present in the source
 repository to determine which dependencies to download. Cachi2 does not parse this file on its own - rather, we rely on

--- a/cachi2/core/package_managers/gomod.py
+++ b/cachi2/core/package_managers/gomod.py
@@ -849,7 +849,7 @@ def _setup_go_toolchain(go_mod_file: RootedPath) -> Go:
     GO_121 = version.Version("1.21")
     go = Go()
     target_version = None
-    go_max_version = version.Version("1.23")
+    go_max_version = version.Version("1.24")
     go_base_version = go.version
     go_mod_version_msg = "go.mod reported versions: '%s'[go], '%s'[toolchain]"
 


### PR DESCRIPTION
  Go 1.24 has recently been [released](https://tip.golang.org/doc/go1.24). See the commit for more information.