### PR TITLE
Add user documentation for cargo package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ when downloading Go modules. See [Go environment variables](https://go.dev/ref/m
 | Package manager                                | Ecosystem            |
 |------------------------------------------------|----------------------|
 | [bundler](#bundler)                            | Ruby                 |
+| [cargo](#cargo)                                | Rust                 |
 | [generic](#generic-fetcher)                    | N/A                  |
 | [gomod](#gomod)                                | Go                   |
 | [npm](#npm)                                    | JavaScript           |
@@ -153,6 +154,17 @@ on the dependencies specified in the [Gemfile](https://bundler.io/v2.5/man/gemfi
 Both files must be present in the source repository so you should check them into your git repository.
 
 See [docs/bundler.md](docs/bundler.md) for more details.
+
+### cargo
+
+<https://doc.rust-lang.org/cargo/>
+
+Cachi2 supports Cargo by invoking the Cargo CLI to fetch Rust dependencies as
+declared in your project, ensuring reproducible builds with explicitly defined
+versions. Make sure to have up-to-date [Cargo.lock](https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html)
+present in your project.
+
+See [docs/cargo.md](docs/cargo.md) for more details.
 
 ### generic fetcher
 

--- a/docs/cargo.md
+++ b/docs/cargo.md
@@ -1,0 +1,66 @@
+# Cargo
+
+<https://doc.rust-lang.org/cargo/>
+
+## Prerequisites
+
+To use Cachi2 with Cargo locally, ensure you have Cargo binary installed on your
+system. Then, ensure that the **Cargo.toml** and **Cargo.lock** are in your
+project directory.
+
+## Usage
+
+Run the following commands in your terminal to prefetch your project's
+dependencies specified in the **Cargo.lock**. It must be synchronized with the **Cargo.toml**
+file. Otherwise, the command will fail.
+
+```bash
+cd path-to-your-rust-project
+cachi2 fetch-deps cargo
+```
+
+The default output directory is `cachi2-output`. You can change it by passing
+the `--output-dir` option for the `fetch-deps` command. See the help message
+for more information.
+
+After prefetching the dependencies, you can use the prefetched dependencies
+to build your project. Make sure to run the following command to update the
+`.cargo/config.toml` to use them. (If the file does not exist in your repository,
+it will be created).
+
+```bash
+cachi2 inject-files --for-output-dir /tmp/cachi2-output cachi2-output
+```
+
+Use `--for-output-dir` to specify the output directory you want to mount or copy
+to the container. The command will update the `.cargo/config.toml` file to use the
+prefetched dependencies from the specified directory.
+
+_There are no environment variables that need to be set for the build phase._
+
+## Hermetic build
+
+After using the `fetch-deps`, and `inject-files` commands to set up the directory,
+you can build your project hermetically. Here is an example of a Dockerfile with
+basic instructions to build a Rust project:
+
+```Dockerfile
+FROM docker.io/library/rust:latest
+
+WORKDIR /app
+
+COPY Cargo.toml Cargo.lock .
+
+...
+
+RUN cargo build --release
+```
+
+Do not forget to mount the `cachi2-output` directory to the container build environment.
+
+```bash
+podman build . \
+  --volume "$(realpath ./cachi2-output)":/tmp/cachi2-output:Z \
+  --network none \
+  --tag my-rust-app
+```


### PR DESCRIPTION
# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
