### PR TITLE
Allow overriding verify_ssl in generic artifact downloader

### DIFF
--- a/cachi2/core/package_managers/general.py
+++ b/cachi2/core/package_managers/general.py
@@ -81,7 +81,7 @@ async def _async_download_binary_file(
             f"aiohttp.ClientSession.get(url: {url}, timeout: {timeout}, raise_for_status: True)"
         )
         async with session.get(
-            url, timeout=timeout, auth=auth, raise_for_status=True, ssl=ssl_context
+            url, timeout=timeout, auth=auth, raise_for_status=True, verify_ssl=getattr(ssl_context, 'ssl_verify', True)
         ) as resp:
             with open(download_path, "wb") as f:
                 while True:


### PR DESCRIPTION
Similar to rpm, this allows the user to override the generic package fetcher's asyncio.get method with `verify_ssl=False` given an input such as ...
```
cachi2 --log-level=debug --config-file=config.yaml fetch-deps --dev-package-managers \
'{"packages": [{"type": "generic", "options": {"ssl": {"ssl_verify": false}}}]}'
```

The input models file needed some re-arranging to resolve class dependencies.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun

