### PR TITLE
generic: Add a more descriptive error message

### DIFF
--- a/cachi2/core/package_managers/generic/models.py
+++ b/cachi2/core/package_managers/generic/models.py
@@ -55,7 +55,7 @@ class LockfileArtifactBase(BaseModel, ABC):
         :return: the validated checksum dict
         """
         if not CHECKSUM_FORMAT.match(value):
-            raise ValueError("Checksum must be in the format 'algorithm:hash'")
+            raise ValueError(f"Checksum must be in the format 'algorithm:hash' (got '{value}')")
         return value
 
     @abstractmethod


### PR DESCRIPTION
When a checksum did not match expectations the original implementation would not provide any clues other than stating that something did not match. This change adds the actual mismatching value to the output to help with finding lock file issues.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
