### PR TITLE
[flake8] Add E731 to the ignored rules

### DIFF
--- a/cachi2/core/models/sbom.py
+++ b/cachi2/core/models/sbom.py
@@ -196,11 +196,10 @@ class Sbom(pydantic.BaseModel):
             args = dict(annotator=annottr, annotationDate=now, annotationType="OTHER")
             pAnnotation = partial(SPDXPackageAnnotation, **args)
 
-            # noqa for trivial helpers.
-            mkcomm = lambda p: json.dumps(dict(name=f"{p.name}", value=f"{p.value}"))  # noqa: E731
-            hashdict = lambda c: dict(name=c.name, version=c.version, purl=c.purl)  # noqa: E731
+            mkcomm = lambda p: json.dumps(dict(name=f"{p.name}", value=f"{p.value}"))
+            hashdict = lambda c: dict(name=c.name, version=c.version, purl=c.purl)
             erefbase = dict(referenceCategory="PACKAGE-MANAGER", referenceType="purl")
-            erefdict = lambda c: dict(referenceLocator=c.purl, **erefbase)  # noqa: E731
+            erefdict = lambda c: dict(referenceLocator=c.purl, **erefbase)
 
             for component in libraries:
                 package_hash = SPDXPackage._calculate_package_hash_from_dict(hashdict(component))
@@ -226,8 +225,7 @@ class Sbom(pydantic.BaseModel):
         # Main function body.
         packages = [create_document_root()] + libs_to_packages(self.components)
         relationships = [create_root_relationship()] + link_to_root(packages)
-        # noqa for a trivial helper.
-        creator = lambda tool: [f"Tool: {tool.name}", f"Organization: {tool.vendor}"]  # noqa: E731
+        creator = lambda tool: [f"Tool: {tool.name}", f"Organization: {tool.vendor}"]
         return SPDXSbom(
             packages=packages,
             relationships=relationships,
@@ -550,11 +548,7 @@ class SPDXSbom(pydantic.BaseModel):
         for rel in self.relationships:
             direct_relationships[rel.spdxElementId].append(rel.relatedSpdxElement)
             inverse_relationships[rel.relatedSpdxElement] = rel.spdxElementId
-        # noqa because the name is bound to make local intent clearer and
-        # first_for() call easier to follow.
-        unidirectionally_related_package = (
-            lambda p: inverse_relationships.get(p) == self.SPDXID  # noqa: E731
-        )
+        unidirectionally_related_package = lambda p: inverse_relationships.get(p) == self.SPDXID
         # Note: defaulting to top-level SPDXID is inherited from the original implementation.
         # It is unclear if it is really needed, but is left around to match the precedent.
         root_id = first_for(unidirectionally_related_package, direct_relationships, self.SPDXID)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,7 @@ ignore = [
   "W503", # line break before binary operator
   "E203", # whitespace before ':'
   "E501", # line too long
+  "E731", # do not assign a lambda expression
 ]
 per-file-ignores = [
   "tests/*:D101,D102,D103", # missing docstring in public class, method, function

--- a/tests/unit/test_merge_spdx.py
+++ b/tests/unit/test_merge_spdx.py
@@ -16,7 +16,7 @@ def _find_roots(sbom: SPDXSbom) -> list[str]:
         spdx_id, related_spdx = rel.spdxElementId, rel.relatedSpdxElement
         direct_rel_map[spdx_id].append(related_spdx)
         inverse_map[related_spdx] = spdx_id
-    unidirectionally_related_package = lambda p: inverse_map.get(p) == sbom.SPDXID  # noqa: E731
+    unidirectionally_related_package = lambda p: inverse_map.get(p) == sbom.SPDXID
     roots = list(filter(unidirectionally_related_package, direct_rel_map))
     return roots
 
@@ -95,8 +95,7 @@ def _assert_root_is_present(sbom: SPDXSbom) -> None:
     # DocumentRoot can be File or Directory:
     fail_msg = "Document root is missing"
     root_pfx = "SPDXRef-DocumentRoot-"
-    # The inline would be too long otherwise, thus lambda, thus noqa.
-    is_root = lambda p: p.SPDXID is not None and p.SPDXID.startswith(root_pfx)  # noqa: E731
+    is_root = lambda p: p.SPDXID is not None and p.SPDXID.startswith(root_pfx)
     assert any(is_root(p) for p in sbom.packages), fail_msg
 
 


### PR DESCRIPTION
E731 - Do not assign a lambda expression, use a def

We have a bunch of occurrences already and seems like this convenience helper pattern is to stay. Rather than putting #noqa directives everywhere let's just ignore the rule globally.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
