### PR TITLE
yarn improvements

### DIFF
--- a/cachi2/core/package_managers/metayarn.py
+++ b/cachi2/core/package_managers/metayarn.py
@@ -15,7 +15,7 @@ def fetch_yarn_source(request: Request) -> RequestOutput:
     # looks now). To preserve this behavior each request is split into individual
     # packages which are assessed one by one.
     fetched_packages = []
-    for package in request.packages:
+    for package in request.yarn_packages:
         new_request = request.model_copy(update={"packages": [package]})
         try:
             fetched_packages.append(fetch_yarn_classic_source(new_request))

--- a/cachi2/core/package_managers/yarn_classic/project.py
+++ b/cachi2/core/package_managers/yarn_classic/project.py
@@ -9,7 +9,7 @@ import json
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Literal, Union
+from typing import Any, Union
 
 from pyarn import lockfile  # type: ignore
 
@@ -17,8 +17,6 @@ from cachi2.core.errors import PackageRejected
 from cachi2.core.rooted_path import RootedPath
 
 log = logging.getLogger(name=__name__)
-
-ConfigKind = Literal["package_json", "yarnlock"]
 
 
 @dataclass
@@ -40,11 +38,6 @@ class _CommonConfigFile(ABC):
     def path(self) -> RootedPath:
         return self._path
 
-    @property
-    @abstractmethod
-    def config_kind(self) -> ConfigKind:
-        """Return kind of ConfigFile instance."""
-
     @classmethod
     @abstractmethod
     def from_file(cls, path: RootedPath) -> "_CommonConfigFile":
@@ -57,11 +50,6 @@ class PackageJson(_CommonConfigFile):
     This class abstracts the underlying attributes and only exposes what
     is relevant for the request processing.
     """
-
-    @property
-    def config_kind(self) -> ConfigKind:
-        """Return kind of this ConfigFile."""
-        return "package_json"
 
     @property
     def install_config(self) -> dict[str, Any]:
@@ -101,11 +89,6 @@ class YarnLock(_CommonConfigFile):
     """
 
     yarn_lockfile: lockfile.Lockfile
-
-    @property
-    def config_kind(self) -> ConfigKind:
-        """Return kind of this ConfigFile."""
-        return "yarnlock"
 
     @classmethod
     def from_file(cls, path: RootedPath) -> "YarnLock":

--- a/tests/unit/package_managers/yarn_classic/test_project.py
+++ b/tests/unit/package_managers/yarn_classic/test_project.py
@@ -70,12 +70,10 @@ def _setup_pnp_installs(rooted_tmp_path: RootedPath, pnp_kind: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "config_file_class, config_file_name, config_file_content, config_kind",
+    "config_file_class, config_file_name, config_file_content",
     [
-        pytest.param(
-            PackageJson, "package.json", VALID_PACKAGE_JSON_FILE, "package_json", id="package_json"
-        ),
-        pytest.param(YarnLock, "yarn.lock", VALID_YARN_LOCK_FILE, "yarnlock", id="yarnlock"),
+        pytest.param(PackageJson, "package.json", VALID_PACKAGE_JSON_FILE, id="package_json"),
+        pytest.param(YarnLock, "yarn.lock", VALID_YARN_LOCK_FILE, id="yarnlock"),
     ],
 )
 def test_config_file_attributes(
@@ -83,7 +81,6 @@ def test_config_file_attributes(
     config_file_class: ConfigFile,
     config_file_name: str,
     config_file_content: str,
-    config_kind: str,
 ) -> None:
     found_config = _prepare_config_file(
         rooted_tmp_path,
@@ -92,7 +89,6 @@ def test_config_file_attributes(
         config_file_content,
     )
     assert found_config.path.root == rooted_tmp_path.root
-    assert found_config.config_kind == config_kind
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
