### PR TITLE
Update yarn.md - workaround when working with sources not fetched from a remore git repo

### DIFF
--- a/docs/yarn.md
+++ b/docs/yarn.md
@@ -127,6 +127,11 @@ document has been completed, then it's essentially just a matter of cachi2 inter
 ``yarn install --mode=skip-build`` to fetch all dependencies (including transitive dependencies).
 
 ### Known pitfalls
+
+If your sources were not fetched from a remote git repo, Cachi2 will get confused about the name of 
+the main package. As workaround, run ``git init; git remote add origin git@url`` to give Cachi2 a
+value when it runs ``git remote show origin`` to define the name of the main package.
+
 If your repository isn't in a pristine state (i.e. you tried to run ``yarn install`` previously on
 your own without Cachi2) what may happen is that Cachi2 will assume the repository makes use of
 [Zero-Installs](#dealing-with-yarn-zero-installs). The workaround here is simple, just run ``yarn

--- a/docs/yarn.md
+++ b/docs/yarn.md
@@ -129,8 +129,9 @@ document has been completed, then it's essentially just a matter of cachi2 inter
 ### Known pitfalls
 
 If your sources were not fetched from a remote git repo, Cachi2 will get confused about the name of 
-the main package. As workaround, run ``git init; git remote add origin git@url`` to give Cachi2 a
-value when it runs ``git remote show origin`` to define the name of the main package.
+the main package, throwing an error: ``InvalidGitRepositoryError for file: URL``. As workaround, run 
+``git init; git remote add origin git@url`` so that ``git remote show origin`` will return a value
+when Cachi2 is defining the name of the main package.
 
 If your repository isn't in a pristine state (i.e. you tried to run ``yarn install`` previously on
 your own without Cachi2) what may happen is that Cachi2 will assume the repository makes use of

--- a/docs/yarn.md
+++ b/docs/yarn.md
@@ -130,7 +130,7 @@ document has been completed, then it's essentially just a matter of cachi2 inter
 
 If your sources were not fetched from a remote git repo, Cachi2 will get confused about the name of 
 the main package, throwing an error: ``InvalidGitRepositoryError for file: URL``. As workaround, run 
-``git init; git remote add origin git@url`` so that ``git remote show origin`` will return a value
+``git init; git remote add origin orgin https://github.com/somewhere/out-there/`` so that ``git remote show origin`` will return a value
 when Cachi2 is defining the name of the main package.
 
 If your repository isn't in a pristine state (i.e. you tried to run ``yarn install`` previously on


### PR DESCRIPTION
Update yarn.md - workaround when working with sources not fetched from a remore git repo

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
