### PR TITLE
setuptools-scm fixes

### DIFF
--- a/.containerignore
+++ b/.containerignore
@@ -1,6 +1,7 @@
 *
 
 !.git/
+!.git_archival.txt
 !cachi2/
 !pyproject.toml
 !requirements.txt

--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,3 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_archival.txt  export-subst

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,7 @@
+# setuptools should no longer need a MANIFEST.in file, but sadly when paired with the
+# setuptools-scm plugin and specifically in a scenario where the fallback_version string needs to
+# be applied setuptools doesn't properly exercise its default package discovery behaviour leading
+# to empty installations, that's where this MANIFEST.in hack comes in and makes sure that our
+# project is properly installed inside the container image environment on this rare occasion.
+
+graft cachi2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ cachi2 = "cachi2.interface.cli:app"
 packages = ["cachi2"]
 
 [tool.setuptools_scm]
+fallback_version = "0.0.0+dev.fallback"
 
 [tool.black]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,6 @@ cachi2 = "cachi2.interface.cli:app"
 packages = ["cachi2"]
 
 [tool.setuptools_scm]
-version_scheme = "post-release"
 
 [tool.black]
 line-length = 100


### PR DESCRIPTION
This is an attempt to fix one version-related aspect of our container image builds. The last 2 patches are a bit controversial, so I'd be inclined to drop them if requested, but they fix a legitimate workflow issue.
See the patch descriptions for detailed info.

FWIW I used a dummy release on my fork to experiment with this, please give it a try: https://github.com/eskultety/cachi2/releases/tag/1.2.3-alpha


# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
