### PR TITLE
.containerignore: Exclude MANIFEST.in

### DIFF
--- a/.containerignore
+++ b/.containerignore
@@ -5,3 +5,4 @@
 !cachi2/
 !pyproject.toml
 !requirements.txt
+!MANIFEST.in


### PR DESCRIPTION
The container build from git worktrees will still fail because of the missing MANIFEST.in file in the container build environment.

Fixes: d6a16c214b8370d08746d46619b0844239777ad1

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
