### PR TITLE
[Rebranding] vol.1 : A tiny prelude

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# 🚧 REBRANDING NOTICE 🚧
+**This project is currently undergoing rebranding
+(see https://github.com/orgs/hermetoproject/discussions/824).**
+
+**You will gradually notice changes to the code base and eventually - the repository name and
+release artifacts. We are taking steps to ensure backwards compatibility, so feel free to continue
+using the project as normal, stay tuned!**
+
 # Cachi2
 
 [![coverage][cachi2-coverage-badge]][cachi2-coverage-status]

--- a/cachi2/interface/cli.py
+++ b/cachi2/interface/cli.py
@@ -97,7 +97,7 @@ def version_callback(value: bool) -> None:
 
 @app.callback()
 @handle_errors
-def cachi2(  # noqa: D103; docstring becomes part of --help message
+def main(  # noqa: D103; docstring becomes part of --help message
     version: bool = typer.Option(
         False,
         "--version",

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,8 +1,6 @@
 import sys
 import tarfile
 from pathlib import Path
-from typing import Generator
-from unittest import mock
 
 import git
 import pytest
@@ -63,10 +61,3 @@ def input_request(tmp_path: Path, request: pytest.FixtureRequest) -> Request:
         output_dir=tmp_path / "output",
         packages=package_input,
     )
-
-
-@pytest.fixture
-def isodate() -> Generator:
-    with mock.patch("datetime.datetime") as mock_datetime:
-        mock_datetime.now.return_value.strftime.return_value = "2021-07-01T00:00:00Z"
-        yield mock_datetime

--- a/tests/unit/extras/test_envfile.py
+++ b/tests/unit/extras/test_envfile.py
@@ -24,8 +24,8 @@ def test_format_based_on_suffix(filename: str, expect_format: EnvFormat) -> None
     "filename, expect_reason",
     [
         (".env", "file has no suffix: .env"),
-        ("cachi2.", "file has no suffix: cachi2."),
-        ("cachi2.yaml", "unsupported suffix: yaml"),
+        ("file.", "file has no suffix: file."),
+        ("file.yaml", "unsupported suffix: yaml"),
     ],
 )
 def test_cannot_determine_format(filename: str, expect_reason: str) -> None:

--- a/tests/unit/models/test_property_semantics.py
+++ b/tests/unit/models/test_property_semantics.py
@@ -7,8 +7,8 @@ from cachi2.core.models.sbom import Component, Property, merge_component_propert
 @pytest.mark.parametrize(
     "components, expect_merged",
     [
-        ([], []),
-        (
+        pytest.param([], [], id="empty_components"),
+        pytest.param(
             # don't merge different components, just sort them by purl and sort their properties
             [
                 Component(
@@ -50,8 +50,9 @@ from cachi2.core.models.sbom import Component, Property, merge_component_propert
                     ],
                 ),
             ],
+            id="no_merging_just_sorted_components",
         ),
-        (
+        pytest.param(
             # do merge identical components
             [
                 Component(
@@ -102,8 +103,9 @@ from cachi2.core.models.sbom import Component, Property, merge_component_propert
                     ],
                 ),
             ],
+            id="merge_identical_components",
         ),
-        (
+        pytest.param(
             # validate that "wheel" property is merged correctly
             [
                 # sdist
@@ -137,6 +139,7 @@ from cachi2.core.models.sbom import Component, Property, merge_component_propert
                     ],
                 )
             ],
+            id="merge_pip_sdist_and_wheel",
         ),
     ],
 )

--- a/tests/unit/package_managers/test_pip.py
+++ b/tests/unit/package_managers/test_pip.py
@@ -4061,14 +4061,23 @@ def test_replace_external_requirements(
 @pytest.mark.parametrize(
     "packages, n_pip_packages",
     [
-        ([{"type": "gomod"}], 0),
-        ([{"type": "pip", "requirements_files": ["requirements.txt"]}], 1),
-        (
+        pytest.param(
+            [{"type": "gomod"}],
+            0,
+            id="not_python_project",
+        ),
+        pytest.param(
+            [{"type": "pip", "requirements_files": ["requirements.txt"]}],
+            1,
+            id="single_python_package",
+        ),
+        pytest.param(
             [
                 {"type": "pip", "requirements_files": ["requirements.txt"]},
                 {"type": "pip", "path": "foo", "requirements_build_files": []},
             ],
             2,
+            id="multiple_python_packages",
         ),
     ],
 )

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -29,6 +29,9 @@ from cachi2.interface.cli import DEFAULT_OUTPUT, DEFAULT_SOURCE, app
 runner = typer.testing.CliRunner()
 
 
+SPDX_EPOCH_STRFTIME = datetime.datetime.fromtimestamp(0).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
 @pytest.fixture
 def tmp_cwd(tmp_path: Path) -> Iterator[Path]:
     """Temporarily change working directory to a pytest tmpdir."""
@@ -635,8 +638,12 @@ class TestFetchDeps:
             ),
         ],
     )
+    @mock.patch("cachi2.core.models.sbom.spdx_now", return_value=SPDX_EPOCH_STRFTIME)
     def test_write_json_output_spdx(
-        self, request_output: RequestOutput, tmp_cwd: Path, isodate: datetime.datetime
+        self,
+        mock_spdx_now: str,
+        request_output: RequestOutput,
+        tmp_cwd: Path,
     ) -> None:
         with mock_fetch_deps(output=request_output):
             invoke_expecting_sucess(app, ["fetch-deps", "--sbom-output-type", "spdx", "gomod"])

--- a/tests/unit/test_resolver.py
+++ b/tests/unit/test_resolver.py
@@ -103,8 +103,10 @@ def test_resolve_packages(tmp_path: Path) -> None:
 @pytest.mark.parametrize(
     "packages, copy_exists",
     [
-        ([{"type": "yarn"}], True),
-        ([{"type": "gomod"}, {"type": "pip"}, {"type": "npm"}], False),
+        pytest.param([{"type": "yarn"}], True, id="single_package"),
+        pytest.param(
+            [{"type": "gomod"}, {"type": "pip"}, {"type": "npm"}], False, id="multiple_packages"
+        ),
     ],
 )
 @mock.patch("cachi2.core.resolver._resolve_packages")

--- a/tests/unit/test_scm.py
+++ b/tests/unit/test_scm.py
@@ -27,8 +27,8 @@ class TestRepoID:
             ("https://git.host.com/some/path", "https://git.host.com/some/path"),
             # credentials
             (
-                "https://student:redhat@github.com/student/cachi2.git",
-                "https://github.com/student/cachi2.git",
+                "https://student:password@github.com/student/repo.git",
+                "https://github.com/student/repo.git",
             ),
             # unsupported
             (


### PR DESCRIPTION
First round of rebranding related changes:
- small but unnoticeable fixes that otherwise impact the rebranding process
- put a rebranding notice in the main README for the time being

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
