### PR TITLE
noxfile: Query PWD from os.environ instead of nox session

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -146,7 +146,7 @@ def generate_test_data(session: Session) -> None:
 @nox.session(name="pip-compile")
 def pip_compile(session: Session) -> None:
     """Update requirements.txt and requirements-extras.txt files."""
-    PWD = session.env["PWD"]
+    PWD = os.environ["PWD"]
     uv_pip_compile_cmd = (
         "pip install uv && "
         # requirements.txt


### PR DESCRIPTION
It can happen that the nox's session doesn't define the variable leading to:

      File "<repo>/noxfile.py", line 150, in pip_compile
      PWD = session.env["PWD"]
          ~~~~~~~~~~~^^^^^^^
      KeyError: 'PWD'

The exact circumstances are unknown, but it happened on a git worktree. In any case os.environ should be more stable because that corresponds to the shell's env directly.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
