### PR TITLE
Containerfile: Maximize layer caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,11 +34,14 @@ RUN dnf -y install \
     python3-setuptools \
     && dnf clean all
 
-COPY . .
+# Install dependencies in a separate layer to maximize layer caching
+COPY requirements.txt .
 RUN python3 -m venv /venv && \
     /venv/bin/pip install --upgrade pip && \
-    /venv/bin/pip install -r requirements.txt --no-deps --no-cache-dir --require-hashes && \
-    /venv/bin/pip install --no-cache-dir .
+    /venv/bin/pip install -r requirements.txt --no-deps --no-cache-dir --require-hashes
+
+COPY . .
+RUN /venv/bin/pip install --no-cache-dir .
 
 ##########################
 # ASSEMBLE THE FINAL IMAGE

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,6 @@ RUN dnf -y install \
 ######################
 FROM base as builder
 WORKDIR /src
-COPY . .
 RUN dnf -y install \
     --setopt install_weak_deps=0 \
     --nodocs \
@@ -35,6 +34,7 @@ RUN dnf -y install \
     python3-setuptools \
     && dnf clean all
 
+COPY . .
 RUN python3 -m venv /venv && \
     /venv/bin/pip install --upgrade pip && \
     /venv/bin/pip install -r requirements.txt --no-deps --no-cache-dir --require-hashes && \

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -134,15 +134,6 @@ class Cachi2Image(ContainerImage):
                 )
         return super().run_cmd_on_image(cmd, tmp_path, mounts, net)
 
-    def __exit__(self, exc_type: Any, exc_value: Any, exc_traceback: Any) -> None:
-        """Override the context manager exit to remove any dangling layers as build side effect."""
-        remove_dangling = "podman rmi --force $(podman images -q --filter 'dangling=true')"
-
-        # Best effort: ignore the return code, because if the dangling filter returns an empty set
-        # podman exits with 125 which is an internal podman error
-        # (in this case: "image name or ID must be specified")
-        run_cmd(remove_dangling, shell=True)
-
 
 def build_image(context_dir: Path, tag: str) -> ContainerImage:
     return _build_image(["podman", "build", str(context_dir)], tag=tag)
@@ -479,22 +470,20 @@ def build_image_and_check_cmd(
         "--for-output-dir",
         f"/tmp/{DEFAULT_OUTPUT}",
     ]
+    (output, exit_code) = cachi2_image.run_cmd_on_image(cmd, tmp_path)
+    assert exit_code == 0, f"Env var file creation failed. output-cmd: {output}"
 
-    with cachi2_image:
-        (output, exit_code) = cachi2_image.run_cmd_on_image(cmd, tmp_path)
-        assert exit_code == 0, f"Env var file creation failed. output-cmd: {output}"
-
-        log.info("Injecting project files")
-        cmd = [
-            "inject-files",
-            str(output_dir),
-            "--for-output-dir",
-            f"/tmp/{DEFAULT_OUTPUT}",
-        ]
-        (output, exit_code) = cachi2_image.run_cmd_on_image(
-            cmd, tmp_path, [(test_repo_dir, test_repo_dir)]
-        )
-        assert exit_code == 0, f"Injecting project files failed. output-cmd: {output}"
+    log.info("Injecting project files")
+    cmd = [
+        "inject-files",
+        str(output_dir),
+        "--for-output-dir",
+        f"/tmp/{DEFAULT_OUTPUT}",
+    ]
+    (output, exit_code) = cachi2_image.run_cmd_on_image(
+        cmd, tmp_path, [(test_repo_dir, test_repo_dir)]
+    )
+    assert exit_code == 0, f"Injecting project files failed. output-cmd: {output}"
 
     log.info("Build container image with all prerequisites retrieved in previous steps")
     container_folder = test_data_dir.joinpath(test_case, "container")


### PR DESCRIPTION
This is mainly about commit 140881e42fd29cecc872407bf5d07328612a6305 which prioritized storage considerations and  a clean overview (due to the dangling images being opaque) over efficiency which, in hindsight, was a **detrimental** decision wrt integration test suite performance. On its own though we'd still not follow best practices when it comes to layer caching and so additional patches are added on top. All patches combined resulted in decreasing a single e2e test execution (`yarn_e2e_test_multiple_packages` was used) from 86s -> 18s (>4x speedup) on my machine using the `throughput-performance` tuned profile.

We could still squeeze some more out of it by doing a similar thing for the test application image builds (which are still removed at the end of the run) with not-as-significant returns, but this PR is supposed to be merely a simple quick hotfix with minimum "new" changes.


# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
