### PR TITLE
yarn: Filter directories in workspace glob resolution

### DIFF
--- a/cachi2/core/package_managers/yarn_classic/workspaces.py
+++ b/cachi2/core/package_managers/yarn_classic/workspaces.py
@@ -60,7 +60,7 @@ def _get_workspace_paths(workspaces_globs: list[str], source_dir: RootedPath) ->
     """Resolve globs within source directory."""
 
     def all_paths_matching(glob: str) -> Generator[Path, None, None]:
-        return (path.resolve() for path in source_dir.path.glob(glob))
+        return (path.resolve() for path in source_dir.path.glob(glob) if path.is_dir())
 
     return list(chain.from_iterable(map(all_paths_matching, workspaces_globs)))
 


### PR DESCRIPTION
# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
