### PR TITLE
docs: generic: Update outdated statement

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -630,8 +630,7 @@ artifacts:
 ```
 
 As with other examples, the command to fetch dependencies is very similar. The default path
-is assumed to be `.`. Since generic fetcher is still an experimental feature, it needs to be
-enabled with the `--dev-package-managers` flag.
+is assumed to be `.`.
 
 ```
 cachi2 fetch-deps --source ./cachi2-generic --output ./cachi2-output generic


### PR DESCRIPTION
It was stated in the docs that generic fetcher must be used with '--dev-package-managers' flag which is not correct anymore. This patch removes this statement.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
