### PR TITLE
[CI] noxfile: Use --no-deps with pip requirements installation

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -34,7 +34,7 @@ nox.options.default_venv_backend = "venv"
 
 def install_requirements(session: Session) -> None:
     """Install requirements for all sessions."""
-    session.install("-r", "requirements-extras.txt")
+    session.install("--no-deps", "-r", "requirements-extras.txt")
 
 
 def parse_supported_python_versions() -> list[str]:


### PR DESCRIPTION
The upstream CI fails with:

    ERROR: In --require-hashes mode, all requirements must have their
    versions pinned with ==. These do not: coverage[toml]>=7.5

By default, pip tries to resolve transitive dependencies of packages when reading the requirements files. Well, that fails if the 'require-hashes' mode is ON. In case one uses a fully resolved and pinned requirements file (we do), pip shouldn't need to spend time trying to re-resolve something that's already resolved, it should use it directly.