### PR TITLE
docs: update fetch-deps usage example to include --sbom-output-type flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,11 @@ and nowhere else.
 cachi2 fetch-deps \
   --source ./my-repo \
   --output ./cachi2-output \
+  --sbom-output-type cyclonedx \
   gomod
 ```
 
-The `fetch-deps` command fetches your project's dependencies and stores them on your disk. You can then use these
-outputs to, say, build a container image.
+The `fetch-deps` command fetches your project's dependencies and stores them on your disk. Cachi2 also produces a detailed SBOM containing information about all the project's components and packages. You can find the SBOM in the output directory.
 
 See [docs/usage.md](docs/usage.md) for a more detailed, practical (*cough*) example of Cachi2 usage.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -38,12 +38,14 @@ The first step in creating hermetic builds is to fetch the dependencies for one 
 cachi2 fetch-deps \
   --source ./foo \
   --output ./cachi2-output \
+  --sbom-output-type cyclonedx \
   '{"path": ".", "type": "<supported package manager>"}'
 ```
 
-* `--source` - the path to a *git repository* on the local disk
-* `--output` - the path to the directory where Cachi2 will write all output
-* `{JSON}`   - specifies a *package* (a directory) within the repository to process
+* `--source`           - the path to a *git repository* on the local disk `[default: .]`
+* `--output`           - the path to the directory where Cachi2 will write all output `[default: ./cachi2-output]`
+* `--sbom-output-type` - the format of generated SBOM, supported values are `cyclonedx` (outputs [CycloneDX v1.4](https://cyclonedx.org/docs/1.4/json)) and `spdx` (outputs [SPDX v2.3](https://spdx.github.io/spdx-spec/v2.3/)). `[default: cyclonedx]`
+* `{JSON}`             - specifies a *package* (a directory) within the repository to process
 
 Note that Cachi2 does not auto-detect which package managers your project uses. You need to tell Cachi2 what to process
 when calling fetch-deps. In the example above, the package path is located at the root of the foo repo,


### PR DESCRIPTION
Updated the fetch-deps examples to include the --sbom-output-type flag.

Closes https://github.com/hermetoproject/cachi2/issues/812

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
